### PR TITLE
Interpret Flags in DS4 Mode Output Report, implementes DS4W "Flash at High Latency" feature

### DIFF
--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -969,6 +969,7 @@ DsHidMini_WriteReport(
 		BOOL Flag_Color = ( Packet->reportBuffer[1] >> 1) & 1U;
 		BOOL Flag_Flash = (Packet->reportBuffer[1] >> 2) & 1U;
 
+		//
 		// Color values (RGB)
 		// 
 		UCHAR r = Packet->reportBuffer[6];

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -1036,6 +1036,10 @@ DsHidMini_WriteReport(
 			}
 		}
 		
+		if (HighLatency) {
+			DS3_SET_LED(pDevCtx, DS3_LED_1 | DS3_LED_2 | DS3_LED_3 | DS3_LED_4);
+		}
+
 		(void)Ds_SendOutputReport(pDevCtx, Ds3OutputReportSourceDualShock4);
 
 		status = STATUS_SUCCESS;

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -965,6 +965,9 @@ DsHidMini_WriteReport(
 
 		DS3_SET_SMALL_RUMBLE_STRENGTH(pDevCtx, Packet->reportBuffer[4]);
 		DS3_SET_LARGE_RUMBLE_STRENGTH(pDevCtx, Packet->reportBuffer[5]);
+		BOOL Flag_Rumble = ( Packet->reportBuffer[1] >> 0) & 1U;
+		BOOL Flag_Color = ( Packet->reportBuffer[1] >> 1) & 1U;
+		BOOL Flag_Flash = (Packet->reportBuffer[1] >> 2) & 1U;
 
 		// Color values (RGB)
 		// 

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -980,22 +980,22 @@ DsHidMini_WriteReport(
 		UCHAR fb_dur = Packet->reportBuffer[9];
 		UCHAR fd_dur = Packet->reportBuffer[10];
 
-		BOOL FlashOrPulse = Flag_Flash && (fb_dur != 0 || fd_dur != 0);
+		BOOL FlashOrPulse = Flag_Flash && ( fb_dur != 0 || fd_dur != 0 );
 		BOOL HighLatency = FALSE;
 
 		if (FlashOrPulse) // High Latency DS4Windows function
-		{
+			 {
 			if (r == 0x32 && g == 0x00 && b == 0x00) { // Hard-coded colors used in Hight Latency warning
 				HighLatency = TRUE;
 			}
 		}
 
-		if (Flag_Rumble) {
+		if ( Flag_Rumble ) {
 			DS3_SET_SMALL_RUMBLE_STRENGTH(pDevCtx, Packet->reportBuffer[4]);
 			DS3_SET_LARGE_RUMBLE_STRENGTH(pDevCtx, Packet->reportBuffer[5]);
 		}
 
-		if (Flag_Color) {
+		if ( Flag_Color ) {
 			//
 			// Single color RED intensity indicates battery level (Light only a single LED from 1 to 4)
 			// 
@@ -1035,8 +1035,8 @@ DsHidMini_WriteReport(
 					DS3_SET_LED(pDevCtx, r << 1);
 			}
 		}
-		
-		if (HighLatency) {
+
+		if ( HighLatency ) {
 			DS3_SET_LED(pDevCtx, DS3_LED_1 | DS3_LED_2 | DS3_LED_3 | DS3_LED_4);
 		}
 

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -981,6 +981,14 @@ DsHidMini_WriteReport(
 		UCHAR fd_dur = Packet->reportBuffer[10];
 
 		BOOL FlashOrPulse = Flag_Flash && (fb_dur != 0 || fd_dur != 0);
+		BOOL HighLatency = FALSE;
+
+		if (FlashOrPulse) // High Latency DS4Windows function
+		{
+			if (r == 0x32 && g == 0x00 && b == 0x00) { // Hard-coded colors used in Hight Latency warning
+				HighLatency = TRUE;
+			}
+		}
 
 		if (Flag_Rumble) {
 			DS3_SET_SMALL_RUMBLE_STRENGTH(pDevCtx, Packet->reportBuffer[4]);

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -974,6 +974,13 @@ DsHidMini_WriteReport(
 		UCHAR g = Packet->reportBuffer[7];
 		UCHAR b = Packet->reportBuffer[8];
 
+		//
+		// Flash Bright and Dark duration
+		// 
+		UCHAR fb_dur = Packet->reportBuffer[9];
+		UCHAR fd_dur = Packet->reportBuffer[10];
+
+		BOOL FlashOrPulse = Flag_Flash && (fb_dur != 0 || fd_dur != 0);
 
 		if (Flag_Rumble) {
 			DS3_SET_SMALL_RUMBLE_STRENGTH(pDevCtx, Packet->reportBuffer[4]);

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -963,8 +963,6 @@ DsHidMini_WriteReport(
 		// 
 		pDevCtx->OutputReport.Mode = Ds3OutputReportModeWriteReportPassThrough;
 
-		DS3_SET_SMALL_RUMBLE_STRENGTH(pDevCtx, Packet->reportBuffer[4]);
-		DS3_SET_LARGE_RUMBLE_STRENGTH(pDevCtx, Packet->reportBuffer[5]);
 		BOOL Flag_Rumble = ( Packet->reportBuffer[1] >> 0) & 1U;
 		BOOL Flag_Color = ( Packet->reportBuffer[1] >> 1) & 1U;
 		BOOL Flag_Flash = (Packet->reportBuffer[1] >> 2) & 1U;
@@ -975,6 +973,12 @@ DsHidMini_WriteReport(
 		UCHAR r = Packet->reportBuffer[6];
 		UCHAR g = Packet->reportBuffer[7];
 		UCHAR b = Packet->reportBuffer[8];
+
+
+		if (Flag_Rumble) {
+			DS3_SET_SMALL_RUMBLE_STRENGTH(pDevCtx, Packet->reportBuffer[4]);
+			DS3_SET_LARGE_RUMBLE_STRENGTH(pDevCtx, Packet->reportBuffer[5]);
+		}
 
 		//
 		// Single color RED intensity indicates battery level (Light only a single LED from 1 to 4)

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -980,43 +980,45 @@ DsHidMini_WriteReport(
 			DS3_SET_LARGE_RUMBLE_STRENGTH(pDevCtx, Packet->reportBuffer[5]);
 		}
 
-		//
-		// Single color RED intensity indicates battery level (Light only a single LED from 1 to 4)
-		// 
-		if (g == 0x00 && b == 0x00)
-		{
-			if (r >= 192)
-				DS3_SET_LED(pDevCtx, DS3_LED_4);
-			else if (r > 128)
-				DS3_SET_LED(pDevCtx, DS3_LED_3);
-			else if (r > 64)
-				DS3_SET_LED(pDevCtx, DS3_LED_2);
-			else
-				DS3_SET_LED(pDevCtx, DS3_LED_1);
-		}
-		//
-		// Single color RED intensity indicates battery level ("Fill" LEDs from 1 to 4)
-		// 
-		else if (g == 0x00 && b == 0xFF)
-		{
-			if (r >= 196)
-				DS3_SET_LED(pDevCtx, DS3_LED_1 | DS3_LED_2 | DS3_LED_3 | DS3_LED_4);
-			else if (r > 128)
-				DS3_SET_LED(pDevCtx, DS3_LED_1 | DS3_LED_2 | DS3_LED_3);
-			else if (r > 64)
-				DS3_SET_LED(pDevCtx, DS3_LED_1 | DS3_LED_2);
-			else
-				DS3_SET_LED(pDevCtx, DS3_LED_1);
-		}
-		//
-		// Decode custom LED status from color RED intensity
-		// 
-		else if (g == 0xFF && b == 0xFF)
-		{
-			if (r == 0x00)
-				DS3_SET_LED(pDevCtx, DS3_LED_OFF);
-			else if (r >= 0x01 && r <= 0x0F)
-				DS3_SET_LED(pDevCtx, r << 1);
+		if (Flag_Color) {
+			//
+			// Single color RED intensity indicates battery level (Light only a single LED from 1 to 4)
+			// 
+			if (g == 0x00 && b == 0x00)
+			{
+				if (r >= 192)
+					DS3_SET_LED(pDevCtx, DS3_LED_4);
+				else if (r > 128)
+					DS3_SET_LED(pDevCtx, DS3_LED_3);
+				else if (r > 64)
+					DS3_SET_LED(pDevCtx, DS3_LED_2);
+				else
+					DS3_SET_LED(pDevCtx, DS3_LED_1);
+			}
+			//
+			// Single color RED intensity indicates battery level ("Fill" LEDs from 1 to 4)
+			// 
+			else if (g == 0x00 && b == 0xFF)
+			{
+				if (r >= 196)
+					DS3_SET_LED(pDevCtx, DS3_LED_1 | DS3_LED_2 | DS3_LED_3 | DS3_LED_4);
+				else if (r > 128)
+					DS3_SET_LED(pDevCtx, DS3_LED_1 | DS3_LED_2 | DS3_LED_3);
+				else if (r > 64)
+					DS3_SET_LED(pDevCtx, DS3_LED_1 | DS3_LED_2);
+				else
+					DS3_SET_LED(pDevCtx, DS3_LED_1);
+			}
+			//
+			// Decode custom LED status from color RED intensity
+			// 
+			else if (g == 0xFF && b == 0xFF)
+			{
+				if (r == 0x00)
+					DS3_SET_LED(pDevCtx, DS3_LED_OFF);
+				else if (r >= 0x01 && r <= 0x0F)
+					DS3_SET_LED(pDevCtx, r << 1);
+			}
 		}
 		
 		(void)Ds_SendOutputReport(pDevCtx, Ds3OutputReportSourceDualShock4);


### PR DESCRIPTION
Implements #54 

Regarding the changes:

- Rumble, color and flash flags are now verified
- Rumble is only set or the Light Bar data translated to LEDs if the appropriate flags are active
- It is now verified if the Light Bar should be pulsing/flashing by checking if the Flash Flag is active while also checking if the Flash Bright or Dark duration bytes are not zero
- It's verified if DS4Windows is in "High Latency" state by checking if 1) the light bar should be pulsing __and__ 2) the color is `r = 0x32` and `g = b = 0x00` (hard-coded values on DS4W side)
- If DS4W is in High Latency State all LEDs will be lighted up on the controller