### PR TITLE
Low battery warning tweak

### DIFF
--- a/sys/DsBth.c
+++ b/sys/DsBth.c
@@ -80,8 +80,6 @@ DsBth_EvtControlWriteTimerFunc(
 			DS3_SET_LED(pDevCtx, DS3_LED_2);
 			break;
 		case DsBatteryStatusLow:
-			DS3_SET_LED(pDevCtx, DS3_LED_1);
-			break;
 		case DsBatteryStatusDying:
 			DS3_SET_LED(pDevCtx, DS3_LED_1);
 			DS3_SET_LED_DURATION(pDevCtx, 0, 0xFF, 15, 127, 127);

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -1594,8 +1594,6 @@ DsBth_HidInterruptReadContinuousRequestCompleted(
 						DS3_SET_LED(pDevCtx, DS3_LED_2);
 						break;
 					case DsBatteryStatusLow:
-						DS3_SET_LED(pDevCtx, DS3_LED_1);
-						break;
 					case DsBatteryStatusDying:
 						DS3_SET_LED(pDevCtx, DS3_LED_1);
 						DS3_SET_LED_DURATION(pDevCtx, 0, 0xFF, 15, 127, 127);

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -1027,7 +1027,7 @@ DsHidMini_WriteReport(
 					DS3_SET_LED(pDevCtx, DS3_LED_3);
 				else if (r > 94)
 					DS3_SET_LED(pDevCtx, DS3_LED_2);
-				else if (r > 40)
+				else if (r > 64)
 					DS3_SET_LED(pDevCtx, DS3_LED_1);
 				else {
 					DS3_SET_LED(pDevCtx, DS3_LED_1);
@@ -1045,7 +1045,7 @@ DsHidMini_WriteReport(
 					DS3_SET_LED(pDevCtx, DS3_LED_1 | DS3_LED_2 | DS3_LED_3);
 				else if (r > 94)
 					DS3_SET_LED(pDevCtx, DS3_LED_1 | DS3_LED_2);
-				else if (r > 40)
+				else if (r > 64)
 					DS3_SET_LED(pDevCtx, DS3_LED_1);
 				else {
 					DS3_SET_LED(pDevCtx, DS3_LED_1);


### PR DESCRIPTION
Because the "dying" state is rarer then a shining pokemon, the low battery was also changed to make LED 1 blink

Related instructions on DS4Windows Mode's Simple LED control were tweaked to reflect these changes.

New Simple LED control values are:

- LED 4: 255 - 203 (Full)
- LED 3: 203 - 149 (High)
- LED 2: 148 - 95 (Medium)
- LED 1: 95 - 65
- Blinking LED 1: < 65 (Low / Dying)

Considering how battery values are translated to DS4 values, this results in the following states when using Simple LED control to represent the controller's current battery with DS4Windows lightbar translation:

(__Wireless__)
- Full (100%): LED 4
- High (75%): LED 3
- Medium (50%): LED 2
- Low (25%) or  Dying (12%): Flashing LED 1

(__Wired__)
- Charged (100%): LED 4
- Charging (36%): LED 1