### PR TITLE
Added OpenTelemetry to XI Bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -342,3 +342,7 @@ healthchecksdb
 /_DSHMC
 /DSHMC.json
 /DSHMC.schema.json
+/XInputBridge/vcpkg_installed/x64-windows-static
+/setup/DsHidMini Driver-SetupFiles
+/setup/DsHidMini Driver-cache
+/ControlApp

--- a/XInputBridge/XInputBridge.cpp
+++ b/XInputBridge/XInputBridge.cpp
@@ -105,8 +105,16 @@ float ToAxis(UCHAR value)
 
 #pragma endregion
 
+nostd::shared_ptr<trace::Tracer> GetTracer()
+{
+	auto provider = trace::Provider::GetTracerProvider();
+	return provider->GetTracer("XInputBridge", OPENTELEMETRY_SDK_VERSION);
+}
+
 void SetDeviceDisconnected(DWORD UserIndex)
 {
+	auto scoped_span = trace::Scope(GetTracer()->StartSpan("SetDeviceDisconnected"));
+
 	if (UserIndex >= DS3_DEVICES_MAX)
 		return;
 
@@ -125,6 +133,8 @@ void SetDeviceDisconnected(DWORD UserIndex)
 
 bool GetDeviceHandle(DWORD UserIndex, hid_device** Handle)
 {
+	auto scoped_span = trace::Scope(GetTracer()->StartSpan("GetDeviceHandle"));
+
 	if (UserIndex >= DS3_DEVICES_MAX)
 		return false;
 
@@ -197,6 +207,8 @@ bool GetDeviceHandle(DWORD UserIndex, hid_device** Handle)
 
 bool GetPacketNumber(DWORD UserIndex, PDS3_RAW_INPUT_REPORT Report, DWORD* PacketNumber)
 {
+	auto scoped_span = trace::Scope(GetTracer()->StartSpan("GetPacketNumber"));
+
 	if (UserIndex >= DS3_DEVICES_MAX)
 		return false;
 
@@ -236,6 +248,8 @@ XINPUTBRIDGE_API DWORD WINAPI XInputGetExtended(
 {
 	DWORD status = ERROR_DEVICE_NOT_CONNECTED;
 	hid_device* device = nullptr;
+
+	auto scoped_span = trace::Scope(GetTracer()->StartSpan("XInputGetExtended"));
 
 	do
 	{
@@ -340,6 +354,8 @@ XINPUTBRIDGE_API DWORD WINAPI XInputGetState(
 {
 	DWORD status = ERROR_DEVICE_NOT_CONNECTED;
 	hid_device* device = nullptr;
+
+	auto scoped_span = trace::Scope(GetTracer()->StartSpan("XInputGetState"));
 
 	do
 	{
@@ -473,6 +489,8 @@ XINPUTBRIDGE_API DWORD WINAPI XInputSetState(
 	DWORD status = ERROR_DEVICE_NOT_CONNECTED;
 	hid_device* device = nullptr;
 
+	auto scoped_span = trace::Scope(GetTracer()->StartSpan("XInputSetState"));
+
 	do
 	{
 		//
@@ -535,6 +553,8 @@ XINPUTBRIDGE_API DWORD WINAPI XInputGetCapabilities(
 {
 	DWORD status = ERROR_DEVICE_NOT_CONNECTED;
 
+	auto scoped_span = trace::Scope(GetTracer()->StartSpan("XInputGetCapabilities"));
+
 	do
 	{
 		//
@@ -591,6 +611,7 @@ XINPUTBRIDGE_API void WINAPI XInputEnable(
 	_In_ BOOL enable
 )
 {
+	auto scoped_span = trace::Scope(GetTracer()->StartSpan("XInputEnable"));
 }
 
 XINPUTBRIDGE_API DWORD WINAPI XInputGetDSoundAudioDeviceGuids(
@@ -627,6 +648,8 @@ XINPUTBRIDGE_API DWORD WINAPI XInputGetStateEx(
 {
 	DWORD status = ERROR_DEVICE_NOT_CONNECTED;
 	hid_device* device = nullptr;
+
+	auto scoped_span = trace::Scope(GetTracer()->StartSpan("XInputGetStateEx"));
 
 	do
 	{

--- a/XInputBridge/XInputBridge.cpp
+++ b/XInputBridge/XInputBridge.cpp
@@ -6,6 +6,7 @@
 
 #include <climits>
 
+
 //
 // Dead-Zone value to stop jittering
 // 

--- a/XInputBridge/XInputBridge.cpp
+++ b/XInputBridge/XInputBridge.cpp
@@ -105,15 +105,19 @@ float ToAxis(UCHAR value)
 
 #pragma endregion
 
+#if defined(SCPLIB_ENABLE_TELEMETRY)
 nostd::shared_ptr<trace::Tracer> GetTracer()
 {
 	auto provider = trace::Provider::GetTracerProvider();
 	return provider->GetTracer("XInputBridge", OPENTELEMETRY_SDK_VERSION);
 }
+#endif
 
 void SetDeviceDisconnected(DWORD UserIndex)
 {
+#if defined(SCPLIB_ENABLE_TELEMETRY)
 	auto scoped_span = trace::Scope(GetTracer()->StartSpan("SetDeviceDisconnected"));
+#endif
 
 	if (UserIndex >= DS3_DEVICES_MAX)
 		return;
@@ -133,7 +137,9 @@ void SetDeviceDisconnected(DWORD UserIndex)
 
 bool GetDeviceHandle(DWORD UserIndex, hid_device** Handle)
 {
+#if defined(SCPLIB_ENABLE_TELEMETRY)
 	auto scoped_span = trace::Scope(GetTracer()->StartSpan("GetDeviceHandle"));
+#endif
 
 	if (UserIndex >= DS3_DEVICES_MAX)
 		return false;
@@ -207,7 +213,9 @@ bool GetDeviceHandle(DWORD UserIndex, hid_device** Handle)
 
 bool GetPacketNumber(DWORD UserIndex, PDS3_RAW_INPUT_REPORT Report, DWORD* PacketNumber)
 {
+#if defined(SCPLIB_ENABLE_TELEMETRY)
 	auto scoped_span = trace::Scope(GetTracer()->StartSpan("GetPacketNumber"));
+#endif
 
 	if (UserIndex >= DS3_DEVICES_MAX)
 		return false;
@@ -249,7 +257,9 @@ XINPUTBRIDGE_API DWORD WINAPI XInputGetExtended(
 	DWORD status = ERROR_DEVICE_NOT_CONNECTED;
 	hid_device* device = nullptr;
 
+#if defined(SCPLIB_ENABLE_TELEMETRY)
 	auto scoped_span = trace::Scope(GetTracer()->StartSpan("XInputGetExtended"));
+#endif
 
 	do
 	{
@@ -355,7 +365,9 @@ XINPUTBRIDGE_API DWORD WINAPI XInputGetState(
 	DWORD status = ERROR_DEVICE_NOT_CONNECTED;
 	hid_device* device = nullptr;
 
+#if defined(SCPLIB_ENABLE_TELEMETRY)
 	auto scoped_span = trace::Scope(GetTracer()->StartSpan("XInputGetState"));
+#endif
 
 	do
 	{
@@ -489,7 +501,9 @@ XINPUTBRIDGE_API DWORD WINAPI XInputSetState(
 	DWORD status = ERROR_DEVICE_NOT_CONNECTED;
 	hid_device* device = nullptr;
 
+#if defined(SCPLIB_ENABLE_TELEMETRY)
 	auto scoped_span = trace::Scope(GetTracer()->StartSpan("XInputSetState"));
+#endif
 
 	do
 	{
@@ -553,7 +567,9 @@ XINPUTBRIDGE_API DWORD WINAPI XInputGetCapabilities(
 {
 	DWORD status = ERROR_DEVICE_NOT_CONNECTED;
 
+#if defined(SCPLIB_ENABLE_TELEMETRY)
 	auto scoped_span = trace::Scope(GetTracer()->StartSpan("XInputGetCapabilities"));
+#endif
 
 	do
 	{
@@ -611,7 +627,9 @@ XINPUTBRIDGE_API void WINAPI XInputEnable(
 	_In_ BOOL enable
 )
 {
+#if defined(SCPLIB_ENABLE_TELEMETRY)
 	auto scoped_span = trace::Scope(GetTracer()->StartSpan("XInputEnable"));
+#endif
 }
 
 XINPUTBRIDGE_API DWORD WINAPI XInputGetDSoundAudioDeviceGuids(
@@ -649,7 +667,9 @@ XINPUTBRIDGE_API DWORD WINAPI XInputGetStateEx(
 	DWORD status = ERROR_DEVICE_NOT_CONNECTED;
 	hid_device* device = nullptr;
 
+#if defined(SCPLIB_ENABLE_TELEMETRY)
 	auto scoped_span = trace::Scope(GetTracer()->StartSpan("XInputGetStateEx"));
+#endif
 
 	do
 	{

--- a/XInputBridge/XInputBridge.vcxproj
+++ b/XInputBridge/XInputBridge.vcxproj
@@ -92,6 +92,9 @@
     <TargetName>XInput1_3</TargetName>
     <OutDir>$(SolutionDir)bin\$(PlatformShortName)\</OutDir>
   </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnableManifest>true</VcpkgEnableManifest>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -99,6 +102,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;XINPUTBRIDGE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)include;</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -117,6 +121,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;XINPUTBRIDGE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)include;</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -135,6 +140,7 @@
       <PreprocessorDefinitions>_DEBUG;XINPUTBRIDGE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)include;</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -153,6 +159,7 @@
       <PreprocessorDefinitions>NDEBUG;XINPUTBRIDGE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)include;</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -166,6 +173,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <None Include="cpp.hint" />
+    <None Include="vcpkg.json" />
     <None Include="XInput.def" />
   </ItemGroup>
   <ItemGroup>

--- a/XInputBridge/XInputBridge.vcxproj.filters
+++ b/XInputBridge/XInputBridge.vcxproj.filters
@@ -19,6 +19,7 @@
     <None Include="XInput.def">
       <Filter>Source Files</Filter>
     </None>
+    <None Include="vcpkg.json" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="framework.h">

--- a/XInputBridge/dllmain.cpp
+++ b/XInputBridge/dllmain.cpp
@@ -1,22 +1,33 @@
 // dllmain.cpp : Defines the entry point for the DLL application.
 #include "framework.h"
 
-BOOL APIENTRY DllMain( HMODULE hModule,
-                       DWORD  ul_reason_for_call,
-                       LPVOID lpReserved
-                     )
-{
-    DisableThreadLibraryCalls(hModule);
+opentelemetry::exporter::jaeger::JaegerExporterOptions opts;
 
-    switch (ul_reason_for_call)
-    {
-    case DLL_PROCESS_ATTACH:
-        hid_init();
-        break;
-    case DLL_PROCESS_DETACH:
-        hid_exit();
-        break;
-    }
-    return TRUE;
+BOOL APIENTRY DllMain(HMODULE hModule,
+	DWORD  ul_reason_for_call,
+	LPVOID lpReserved
+)
+{
+	DisableThreadLibraryCalls(hModule);
+
+	switch (ul_reason_for_call)
+	{
+	case DLL_PROCESS_ATTACH:
+		hid_init();
+
+		{
+			auto exporter = jaeger::JaegerExporterFactory::Create(opts);
+			auto processor = trace_sdk::SimpleSpanProcessorFactory::Create(std::move(exporter));
+			std::shared_ptr<opentelemetry::trace::TracerProvider> provider =
+				trace_sdk::TracerProviderFactory::Create(std::move(processor));
+			// Set the global trace provider
+			trace::Provider::SetTracerProvider(provider);
+		}
+		break;
+	case DLL_PROCESS_DETACH:
+		hid_exit();
+		break;
+	}
+	return TRUE;
 }
 

--- a/XInputBridge/dllmain.cpp
+++ b/XInputBridge/dllmain.cpp
@@ -1,7 +1,9 @@
 // dllmain.cpp : Defines the entry point for the DLL application.
 #include "framework.h"
 
+#if defined(SCPLIB_ENABLE_TELEMETRY)
 opentelemetry::exporter::jaeger::JaegerExporterOptions opts;
+#endif
 
 BOOL APIENTRY DllMain(HMODULE hModule,
 	DWORD  ul_reason_for_call,
@@ -15,6 +17,7 @@ BOOL APIENTRY DllMain(HMODULE hModule,
 	case DLL_PROCESS_ATTACH:
 		hid_init();
 
+#if defined(SCPLIB_ENABLE_TELEMETRY)
 		{
 			auto exporter = jaeger::JaegerExporterFactory::Create(opts);
 			auto processor = trace_sdk::SimpleSpanProcessorFactory::Create(std::move(exporter));
@@ -23,6 +26,7 @@ BOOL APIENTRY DllMain(HMODULE hModule,
 			// Set the global trace provider
 			trace::Provider::SetTracerProvider(provider);
 		}
+#endif
 		break;
 	case DLL_PROCESS_DETACH:
 		hid_exit();

--- a/XInputBridge/framework.h
+++ b/XInputBridge/framework.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#define NOMINMAX
 #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
 // Windows Header Files
 #include <Windows.h>
@@ -11,3 +12,17 @@
 #include <DsHidMini/ScpTypes.h>
 #include <DsHidMini/Ds3Types.h>
 #include <hidapi/hidapi.h>
+
+//
+// OpenTelemetry
+// 
+
+#include "opentelemetry/exporters/jaeger/jaeger_exporter_factory.h"
+#include "opentelemetry/sdk/trace/simple_processor_factory.h"
+#include "opentelemetry/sdk/trace/tracer_provider_factory.h"
+#include "opentelemetry/trace/provider.h"
+
+namespace trace     = opentelemetry::trace;
+namespace nostd     = opentelemetry::nostd;
+namespace trace_sdk = opentelemetry::sdk::trace;
+namespace jaeger    = opentelemetry::exporter::jaeger;

--- a/XInputBridge/framework.h
+++ b/XInputBridge/framework.h
@@ -4,6 +4,12 @@
 
 #pragma once
 
+/*
+ * Uncomment to enable building with OpenTelemetry to allow recording performance traces
+ * The library size will get inflated quite a bit as it gets statically linked in
+ */
+//#define SCPLIB_ENABLE_TELEMETRY
+
 #define NOMINMAX
 #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
 // Windows Header Files
@@ -17,6 +23,7 @@
 // OpenTelemetry
 // 
 
+#if defined(SCPLIB_ENABLE_TELEMETRY)
 #include "opentelemetry/exporters/jaeger/jaeger_exporter_factory.h"
 #include "opentelemetry/sdk/trace/simple_processor_factory.h"
 #include "opentelemetry/sdk/trace/tracer_provider_factory.h"
@@ -26,3 +33,4 @@ namespace trace     = opentelemetry::trace;
 namespace nostd     = opentelemetry::nostd;
 namespace trace_sdk = opentelemetry::sdk::trace;
 namespace jaeger    = opentelemetry::exporter::jaeger;
+#endif

--- a/XInputBridge/vcpkg.json
+++ b/XInputBridge/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "xinputbridge",
+  "version": "3.0.0",
+  "description": "SCP XInput Bridge (Proxy DLL)",
+  "license": "MIT",
+  "supports": "!(arm | uwp)",
+  "dependencies": [
+    { "name": "hidapi" },
+    {
+      "name": "opentelemetry-cpp",
+      "features": [ "jaeger" ]
+    }
+  ]
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,3 +58,4 @@ deploy:
 cache:
 - C:\projects\DMF
 - C:\Tools\vcpkg
+- C:\Users\appveyor\AppData\Local\vcpkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,3 +57,4 @@ deploy:
     appveyor_repo_tag: true
 cache:
 - C:\projects\DMF
+- C:\Tools\vcpkg

--- a/dshidmini.sln.DotSettings
+++ b/dshidmini.sln.DotSettings
@@ -7,7 +7,9 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=DSHM/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Gamepad/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MSHIDUMDF/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=NOMINMAX/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ourself/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=SCPLIB/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Sixaxis/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=XINPUT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=XINPUTHID/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
To help identify performance bottlenecks I've added a compiler switch to optionally build it with [OpenTelemetry](https://opentelemetry.io/) and [Jaeger Tracing](https://www.jaegertracing.io/) support to get performance metrics. I don't build it in by default since it inflates the binary size quite a bit.