### PR TITLE
Fixed rescaling not calculating if not using device-specific properties

### DIFF
--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -641,69 +641,69 @@ ConfigLoadForDevice(
 			ConfigNodeParse(deviceNode, Context, IsHotReload);
 		}
 
-		//
-		// Verify if SMtoBMConversion values are valid and attempt to calculate rescaling constants in case they are
-		// 
-		if (
-			Context->Configuration.RumbleSettings.SMToBMConversion.RescaleMaxValue > Context->Configuration.RumbleSettings.SMToBMConversion.RescaleMinValue
-			&& Context->Configuration.RumbleSettings.SMToBMConversion.RescaleMinValue > 0
-			)
-		{
-			Context->Configuration.RumbleSettings.SMToBMConversion.ConstA =
-				(DOUBLE)(Context->Configuration.RumbleSettings.SMToBMConversion.RescaleMaxValue - Context->Configuration.RumbleSettings.SMToBMConversion.RescaleMinValue) / (254);
-
-			Context->Configuration.RumbleSettings.SMToBMConversion.ConstB =
-				Context->Configuration.RumbleSettings.SMToBMConversion.RescaleMaxValue - Context->Configuration.RumbleSettings.SMToBMConversion.ConstA * 255;
-
-			TraceVerbose(
-				TRACE_CONFIG,
-				"SMToBMConversion rescaling constants: A = %f and B = %f.",
-				Context->Configuration.RumbleSettings.SMToBMConversion.ConstA,
-				Context->Configuration.RumbleSettings.SMToBMConversion.ConstB
-			);
-
-		}
-		else
-		{
-			TraceVerbose(
-				TRACE_CONFIG,
-				"Invalid values found for SMToBMConversion. Setting disabled."
-			);
-			Context->Configuration.RumbleSettings.SMToBMConversion.Enabled = FALSE;
-		}
-
-		//
-		// Verify if BMStrRescale values are valid and attempt to calculate rescaling constants in case they are
-		// 
-		if (
-			Context->Configuration.RumbleSettings.BMStrRescale.MaxValue > Context->Configuration.RumbleSettings.BMStrRescale.MinValue
-			&& Context->Configuration.RumbleSettings.BMStrRescale.MinValue > 0
-			)
-		{
-			Context->Configuration.RumbleSettings.BMStrRescale.ConstA =
-				(DOUBLE)(Context->Configuration.RumbleSettings.BMStrRescale.MaxValue - Context->Configuration.RumbleSettings.BMStrRescale.MinValue) / (254);
-
-			Context->Configuration.RumbleSettings.BMStrRescale.ConstB =
-				Context->Configuration.RumbleSettings.BMStrRescale.MaxValue - Context->Configuration.RumbleSettings.BMStrRescale.ConstA * 255;
-
-			TraceVerbose(
-				TRACE_CONFIG,
-				"BMStrRescale rescaling constants: A = %f and B = %f.",
-				Context->Configuration.RumbleSettings.BMStrRescale.ConstA,
-				Context->Configuration.RumbleSettings.BMStrRescale.ConstB
-			);
-		}
-		else
-		{
-			TraceVerbose(
-				TRACE_CONFIG,
-				"Invalid values found for BMStrRescale. Setting disabled."
-			);
-
-			Context->Configuration.RumbleSettings.BMStrRescale.Enabled = FALSE;
-		}
-
 	} while (FALSE);
+
+	//
+	// Verify if SMtoBMConversion values are valid and attempt to calculate rescaling constants in case they are
+	// 
+	if (
+		Context->Configuration.RumbleSettings.SMToBMConversion.RescaleMaxValue > Context->Configuration.RumbleSettings.SMToBMConversion.RescaleMinValue
+		&& Context->Configuration.RumbleSettings.SMToBMConversion.RescaleMinValue > 0
+		)
+	{
+		Context->Configuration.RumbleSettings.SMToBMConversion.ConstA =
+			(DOUBLE)(Context->Configuration.RumbleSettings.SMToBMConversion.RescaleMaxValue - Context->Configuration.RumbleSettings.SMToBMConversion.RescaleMinValue) / (254);
+
+		Context->Configuration.RumbleSettings.SMToBMConversion.ConstB =
+			Context->Configuration.RumbleSettings.SMToBMConversion.RescaleMaxValue - Context->Configuration.RumbleSettings.SMToBMConversion.ConstA * 255;
+
+		TraceVerbose(
+			TRACE_CONFIG,
+			"SMToBMConversion rescaling constants: A = %f and B = %f.",
+			Context->Configuration.RumbleSettings.SMToBMConversion.ConstA,
+			Context->Configuration.RumbleSettings.SMToBMConversion.ConstB
+		);
+
+	}
+	else
+	{
+		TraceVerbose(
+			TRACE_CONFIG,
+			"Invalid values found for SMToBMConversion. Setting disabled."
+		);
+		Context->Configuration.RumbleSettings.SMToBMConversion.Enabled = FALSE;
+	}
+
+	//
+	// Verify if BMStrRescale values are valid and attempt to calculate rescaling constants in case they are
+	// 
+	if (
+		Context->Configuration.RumbleSettings.BMStrRescale.MaxValue > Context->Configuration.RumbleSettings.BMStrRescale.MinValue
+		&& Context->Configuration.RumbleSettings.BMStrRescale.MinValue > 0
+		)
+	{
+		Context->Configuration.RumbleSettings.BMStrRescale.ConstA =
+			(DOUBLE)(Context->Configuration.RumbleSettings.BMStrRescale.MaxValue - Context->Configuration.RumbleSettings.BMStrRescale.MinValue) / (254);
+
+		Context->Configuration.RumbleSettings.BMStrRescale.ConstB =
+			Context->Configuration.RumbleSettings.BMStrRescale.MaxValue - Context->Configuration.RumbleSettings.BMStrRescale.ConstA * 255;
+
+		TraceVerbose(
+			TRACE_CONFIG,
+			"BMStrRescale rescaling constants: A = %f and B = %f.",
+			Context->Configuration.RumbleSettings.BMStrRescale.ConstA,
+			Context->Configuration.RumbleSettings.BMStrRescale.ConstB
+		);
+	}
+	else
+	{
+		TraceVerbose(
+			TRACE_CONFIG,
+			"Invalid values found for BMStrRescale. Setting disabled."
+		);
+
+		Context->Configuration.RumbleSettings.BMStrRescale.Enabled = FALSE;
+	}
 
 	if (config_json)
 	{


### PR DESCRIPTION
The block of code that calculates the rumble constants used in rescaling functions was in a place that didn't run if not using device-specific settings. Moved it to the correct place.